### PR TITLE
 avoid including node libraries in build, close #8

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "homepage": "https://cesiumjs.org",
   "license": "Apache-2.0",
   "devDependencies": {
-    "cesium": "^1.39.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.7",
     "html-webpack-plugin": "^2.30.1",
@@ -25,6 +24,9 @@
     "url-loader": "^0.6.2",
     "webpack": "^3.5.6",
     "webpack-dev-server": "^2.9.1"
+  },
+  "dependencies": {
+    "cesium": "^1.46.1"
   },
   "scripts": {
     "build": "node_modules/.bin/webpack --config webpack.config.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,8 +25,12 @@ module.exports = [{
         toUrlUndefined: true
     },
     node: {
-        // Resolve node module use of fs
-        fs: "empty"
+        // Avoid including node libraries
+        fs: "empty",
+        http: "empty",
+        https: "empty",
+        zlib: "empty",
+        buffer: "empty"
     },
     resolve: {
         alias: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,8 @@ module.exports = [{
         http: "empty",
         https: "empty",
         zlib: "empty",
-        buffer: "empty"
+        buffer: "empty",
+        url: "empty"
     },
     resolve: {
         alias: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,10 +27,10 @@ module.exports = [{
     node: {
         // Avoid including node libraries
         fs: "empty",
+        Buffer: false,
         http: "empty",
         https: "empty",
         zlib: "empty",
-        buffer: "empty",
         url: "empty"
     },
     resolve: {

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -31,7 +31,8 @@ module.exports = [{
         http: "empty",
         https: "empty",
         zlib: "empty",
-        buffer: "empty"
+        buffer: "empty",
+        url: "empty"
     },
     resolve: {
         alias: {

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -28,10 +28,10 @@ module.exports = [{
     node: {
         // Avoid including node libraries
         fs: "empty",
+        Buffer: false,
         http: "empty",
         https: "empty",
         zlib: "empty",
-        buffer: "empty",
         url: "empty"
     },
     resolve: {

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -26,8 +26,12 @@ module.exports = [{
         toUrlUndefined: true
     },
     node: {
-        // Resolve node module use of fs
-        fs: "empty"
+        // Avoid including node libraries
+        fs: "empty",
+        http: "empty",
+        https: "empty",
+        zlib: "empty",
+        buffer: "empty"
     },
     resolve: {
         alias: {


### PR DESCRIPTION
this pr updates the cesium dep, moves it from devDependencies into dependencies and avoids including node libraries in the build 