### PR TITLE
Update to latest version of everything and Cesium via Node/ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cesium-webpack-example
 
-The minimum recommended setup for an application using [Cesium](https://cesiumjs.org/) with [Webpack](https://webpack.js.org/concepts/).
+A minimal recommended setup for an applications using [Cesium](https://cesiumjs.org/) with [Webpack](https://webpack.js.org/concepts/).
 
 [![Build Status](https://travis-ci.org/AnalyticalGraphicsInc/cesium-webpack-example.svg?branch=using-custom-loader)](https://travis-ci.org/AnalyticalGraphicsInc/cesium-webpack-example)
 
@@ -20,86 +20,24 @@ Navigate to `localhost:8080`.
 
 ##### Configurations
 
-We've included two webpack configuration files in this repository. `webpack.config.js` contains the minimum recommended configuration for getting setup and configuration for running the development server. `webpack.release.config.js` contains an optimized configuration for production use.
+We've included two webpack configuration files in this repository. `webpack.config.js` contains configuration for development while `webpack.release.config.js` contains an optimized configuration for production use.
 
 ### Requiring Cesium in your application
 
-Using either the `build` or `release` configurations provided, there are several ways to include Cesium in your application. There is the [CommonJS](http://requirejs.org/docs/commonjs.html) style syntax which uses `require`, and the newer [ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) style syntax which uses the `import` keyword. Both are supported by webpack.
+We recommend using Cesium as an [ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) module, via the `import` keyword.
 
-You can also include all modules under the global Cesium object using `Cesium.js`, or the individual modules. Requiring individual modules is preferred, resulting in smaller bundle sizes and better performance in your application. See the [Performance Configurations](#performance-configurations) section for more information on improving performance in your application.
- 
-#### CommonJS `require`
+#### Import named modules from Cesium
 
-##### Require specific modules from Cesium (preferred over global)
-
-	var Color = require('cesium/Core/Color');
+	import { Color } from 'cesium';
 	var c = Color.fromRandom();
 
-##### Require the global Cesium object
-
- 	var Cesium = require('cesium/Cesium');
- 	var viewer = new Cesium.Viewer('cesiumContainer');
-
-##### Require Cesium static asset files
-
- 	require('cesium/Widgets/widgets.css');
-
- 	require('cesium/Assets/Textures/pin.svg');
-
-
-#### ES6 style `import`
-
-##### Import specific modules specific modules from Cesium (preferred over global)
-
-	import Color from 'cesium/core/Color';
-	var c = Color.fromRandom();
-
-##### Import the global Cesium object
-
- 	import Cesium from 'cesium/Cesium';
- 	var viewer = new Cesium.Viewer('cesiumContainer');
-
-##### Import Cesium static asset files
+#### Import Cesium static asset files
 	
-	import 'cesium/Widgets/widgets.css';
+	import "cesium/Build/Cesium/Widgets/widgets.css";
 
-	import 'cesium/Assets/Textures/pin.svg';
+### Treeshaking
 
-
-### Using another Cesium location
-
-We've set the `cesiumSource` location to be the contents of the Cesium npm module.
-
-	var cesiumSource = path.resolve(__dirname, 'node_modules/cesium/Source');
-
-If, however, you want to use a different version of Cesium— for example, if you've cloned the Cesium source code directly— just set the Cesium location to the appropriate path.
-
-	var cesiumSource = path.resolve(__dirname, '../path/to/cesium/Source');
-
-You could even point to a branch in GitHub or another url in your `package.json` file.
-
-### Source maps
-
-Enable source maps in development for easier debugging. They are only available when using the development server. There are many [options](https://webpack.js.org/configuration/devtool/) available. The one suggested here is `eval` for a balance of fast build and rebuild time and allowing evaluation of the webpack generated code.
-
-Source maps can be enabled with the following config object:
-
-	devTool: `eval`
-
-### Performance configurations
-
-The following optimizations are recommended for building for production and will increase performance and result in smaller bundle sizes. An example of these configurations can be found in `webpack.release.config.js`.
-
-For best performance, make sure you are requiring individual modules from Cesium instead of the global Cesium object. Additionally, copy only the static assets that your app requires with the `CopyWebpackPlugin` by taking advantage of the [pattern options](https://github.com/webpack-contrib/copy-webpack-plugin#pattern-properties).
-
-#### Bundle size comparisons
-
-Here is a comparison of the size of the separated `cesium.js` bundle for `release` and `build` configurations, for using the global `Cesium` object and including individual modules for the Hello World viewer.
-
-|     | `build` | `release` | 'build' (gzipped) | `release` (gzipped) |
-| --- | --- | --- | --- | ---|
-| `Cesium` object | 9.91 MB | 2.82 MB | 1.64 MB | 745 kB |
-| modules | 7.43 MB | 1.91 MB | 1.17 MB | 513 kB | 
+`webpack.release.config.js` enables tree-shaking of CesiumJS modules so that unused modules are not included in the production bundle. See Webpack's [Tree Shaking](https://webpack.js.org/guides/tree-shaking/) documentation for more details.
 
 ##### Removing pragmas
 
@@ -127,50 +65,6 @@ rules: [{
 		}
 	}]
 }]
-```
-
-##### Uglify and minify
-
-Compress the final size of the bundle by minifying included JavaScript using UglifyJS with the [`uglifyjs-webpack-plugin`](https://webpack.js.org/plugins/uglifyjs-webpack-plugin/).
-
-Install the plugin,
-
-```
-npm install uglifyjs-webpack-plugin --save-dev
-```
-
-require it,
-
-```
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-```
-
-and include it in the list of plugins.
-
-```
-plugins: [
-	new UglifyJsPlugin()
-]
-```
-
-Additionally, minify the CSS files when loaded with the `css-loader`
-
-```
-module: {
-	rules: [
-	{
-		test: /\.css$/,
-		use: [ 
-			'style-loader', 
-			{
-				loader: 'css-loader',
-				options: {
-					minimize: true
-				}
-			}
-		]
-	},
-}
 ```
 
 ## Contributions

--- a/package.json
+++ b/package.json
@@ -15,16 +15,17 @@
   "homepage": "https://cesiumjs.org",
   "license": "Apache-2.0",
   "devDependencies": {
-    "cesium": "^1.39.0",
-    "copy-webpack-plugin": "^4.0.1",
-    "css-loader": "^0.28.7",
-    "html-webpack-plugin": "^2.30.1",
+    "cesium": "http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/no-import-meta/cesium-1.62.0-no-import-meta32711.tgz",
+    "copy-webpack-plugin": "^5.0.4",
+    "css-loader": "^3.2.0",
+    "html-webpack-plugin": "^3.2.0",
     "strip-pragma-loader": "^1.0.0",
-    "style-loader": "^0.18.2",
-    "uglifyjs-webpack-plugin": "^1.0.0-beta.3",
-    "url-loader": "^0.6.2",
-    "webpack": "^3.5.6",
-    "webpack-dev-server": "^2.9.1"
+    "style-loader": "^1.0.0",
+    "uglifyjs-webpack-plugin": "^2.2.0",
+    "url-loader": "^2.2.0",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.9",
+    "webpack-dev-server": "^3.9.0"
   },
   "scripts": {
     "build": "node_modules/.bin/webpack --config webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "example"
   ],
   "author": {
-    "name": "Analytical Graphics, Inc.",
-    "url": "https://www.agi.com"
+    "name": "Cesium GS, Inc.",
+    "url": "https://cesium.com"
   },
   "homepage": "https://cesiumjs.org",
   "license": "Apache-2.0",
+  "dependencies": {
+    "cesium": "http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/no-import-meta/cesium-1.62.0-no-import-meta32711.tgz"
+  },
   "devDependencies": {
-    "cesium": "http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/no-import-meta/cesium-1.62.0-no-import-meta32711.tgz",
     "copy-webpack-plugin": "^5.0.4",
     "css-loader": "^3.2.0",
     "html-webpack-plugin": "^3.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,42 @@
-require('cesium/Widgets/widgets.css');
-require('./css/main.css');
 
-var Cesium = require('cesium/Cesium');
+import {
+    Cartesian3,
+    Color,
+    defined,
+    Math as CesiumMath,
+    Matrix4,
+    ParticleBurst,
+    ParticleSystem,
+    SphereEmitter,
+    Transforms,
+    Viewer
+} from 'cesium';
+
+import "cesium/Build/Cesium/Widgets/widgets.css";
+import "./css/main.css";
 
 // Example app
 
-var viewer = new Cesium.Viewer('cesiumContainer');
+var viewer = new Viewer('cesiumContainer');
 
 var scene = viewer.scene;
 scene.debugShowFramesPerSecond = true;
 
-Cesium.Math.setRandomNumberSeed(315);
+CesiumMath.setRandomNumberSeed(315);
 
-var modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883));
-var emitterInitialLocation = new Cesium.Cartesian3(0.0, 0.0, 100.0);
+var modelMatrix = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromDegrees(-75.59777, 40.03883));
+var emitterInitialLocation = new Cartesian3(0.0, 0.0, 100.0);
 
 var particleCanvas;
 
 function getImage() {
-    if (!Cesium.defined(particleCanvas)) {
+    if (!defined(particleCanvas)) {
         particleCanvas = document.createElement('canvas');
         particleCanvas.width = 20;
         particleCanvas.height = 20;
         var context2D = particleCanvas.getContext('2d');
         context2D.beginPath();
-        context2D.arc(8, 8, 8, 0, Cesium.Math.TWO_PI, true);
+        context2D.arc(8, 8, 8, 0, CesiumMath.TWO_PI, true);
         context2D.closePath();
         context2D.fillStyle = 'rgb(255, 255, 255)';
         context2D.fill();
@@ -39,20 +51,20 @@ var burstSize = 400.0;
 var lifetime = 10.0;
 var numberOfFireworks = 20.0;
 
-var emitterModelMatrixScratch = new Cesium.Matrix4();
+var emitterModelMatrixScratch = new Matrix4();
 
 function createFirework(offset, color, bursts) {
-    var position = Cesium.Cartesian3.add(emitterInitialLocation, offset, new Cesium.Cartesian3());
-    var emitterModelMatrix = Cesium.Matrix4.fromTranslation(position, emitterModelMatrixScratch);
-    var particleToWorld = Cesium.Matrix4.multiply(modelMatrix, emitterModelMatrix, new Cesium.Matrix4());
-    var worldToParticle = Cesium.Matrix4.inverseTransformation(particleToWorld, particleToWorld);
+    var position = Cartesian3.add(emitterInitialLocation, offset, new Cartesian3());
+    var emitterModelMatrix = Matrix4.fromTranslation(position, emitterModelMatrixScratch);
+    var particleToWorld = Matrix4.multiply(modelMatrix, emitterModelMatrix, new Matrix4());
+    var worldToParticle = Matrix4.inverseTransformation(particleToWorld, particleToWorld);
 
-    var size = Cesium.Math.randomBetween(minimumExplosionSize, maximumExplosionSize);
-    var particlePositionScratch = new Cesium.Cartesian3();
-    var force = function(particle) {
-        var position = Cesium.Matrix4.multiplyByPoint(worldToParticle, particle.position, particlePositionScratch);
-        if (Cesium.Cartesian3.magnitudeSquared(position) >= size * size) {
-            Cesium.Cartesian3.clone(Cesium.Cartesian3.ZERO, particle.velocity);
+    var size = CesiumMath.randomBetween(minimumExplosionSize, maximumExplosionSize);
+    var particlePositionScratch = new Cartesian3();
+    var force = function (particle) {
+        var position = Matrix4.multiplyByPoint(worldToParticle, particle.position, particlePositionScratch);
+        if (Cartesian3.magnitudeSquared(position) >= size * size) {
+            Cartesian3.clone(Cartesian3.ZERO, particle.velocity);
         }
     };
 
@@ -61,21 +73,21 @@ function createFirework(offset, color, bursts) {
     var maxLife = 1.0;
     var life = normalSize * (maxLife - minLife) + minLife;
 
-    scene.primitives.add(new Cesium.ParticleSystem({
-        image : getImage(),
-        startColor : color,
-        endColor : color.withAlpha(0.0),
-        life : life,
-        speed : 100.0,
-        width : particlePixelSize,
-        height : particlePixelSize,
-        rate : 0,
-        emitter : new Cesium.SphereEmitter(0.1),
-        bursts : bursts,
-        lifeTime : lifetime,
-        forces : [force],
-        modelMatrix : modelMatrix,
-        emitterModelMatrix : emitterModelMatrix
+    scene.primitives.add(new ParticleSystem({
+        image: getImage(),
+        startColor: color,
+        endColor: color.withAlpha(0.0),
+        life: life,
+        speed: 100.0,
+        width: particlePixelSize,
+        height: particlePixelSize,
+        rate: 0,
+        emitter: new SphereEmitter(0.1),
+        bursts: bursts,
+        lifeTime: lifetime,
+        forces: [force],
+        modelMatrix: modelMatrix,
+        emitterModelMatrix: emitterModelMatrix
     }));
 }
 
@@ -87,40 +99,40 @@ var zMin = -50.0;
 var zMax = 50.0;
 
 var colorOptions = [{
-    minimumRed : 0.75,
-    green : 0.0,
-    minimumBlue : 0.8,
-    alpha : 1.0
+    minimumRed: 0.75,
+    green: 0.0,
+    minimumBlue: 0.8,
+    alpha: 1.0
 }, {
-    red : 0.0,
-    minimumGreen : 0.75,
-    minimumBlue : 0.8,
-    alpha : 1.0
+    red: 0.0,
+    minimumGreen: 0.75,
+    minimumBlue: 0.8,
+    alpha: 1.0
 }, {
-    red : 0.0,
-    green : 0.0,
-    minimumBlue : 0.8,
-    alpha : 1.0
+    red: 0.0,
+    green: 0.0,
+    minimumBlue: 0.8,
+    alpha: 1.0
 }, {
-    minimumRed : 0.75,
-    minimumGreen : 0.75,
-    blue : 0.0,
-    alpha : 1.0
+    minimumRed: 0.75,
+    minimumGreen: 0.75,
+    blue: 0.0,
+    alpha: 1.0
 }];
 
 for (var i = 0; i < numberOfFireworks; ++i) {
-    var x = Cesium.Math.randomBetween(xMin, xMax);
-    var y = Cesium.Math.randomBetween(yMin, yMax);
-    var z = Cesium.Math.randomBetween(zMin, zMax);
-    var offset = new Cesium.Cartesian3(x, y, z);
-    var color = Cesium.Color.fromRandom(colorOptions[i % colorOptions.length]);
+    var x = CesiumMath.randomBetween(xMin, xMax);
+    var y = CesiumMath.randomBetween(yMin, yMax);
+    var z = CesiumMath.randomBetween(zMin, zMax);
+    var offset = new Cartesian3(x, y, z);
+    var color = Color.fromRandom(colorOptions[i % colorOptions.length]);
 
     var bursts = [];
     for (var j = 0; j < 3; ++j) {
-        bursts.push(new Cesium.ParticleBurst({
-            time : Cesium.Math.nextRandomNumber() * lifetime,
-            minimum : burstSize,
-            maximum : burstSize
+        bursts.push(new ParticleBurst({
+            time: CesiumMath.nextRandomNumber() * lifetime,
+            minimum: burstSize,
+            maximum: burstSize
         }));
     }
 
@@ -128,11 +140,11 @@ for (var i = 0; i < numberOfFireworks; ++i) {
 }
 
 var camera = viewer.scene.camera;
-var cameraOffset = new Cesium.Cartesian3(-300.0, 0.0, 0.0);
+var cameraOffset = new Cartesian3(-300.0, 0.0, 0.0);
 camera.lookAtTransform(modelMatrix, cameraOffset);
-camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+camera.lookAtTransform(Matrix4.IDENTITY);
 
-var toFireworks = Cesium.Cartesian3.subtract(emitterInitialLocation, cameraOffset, new Cesium.Cartesian3());
-Cesium.Cartesian3.normalize(toFireworks, toFireworks);
-var angle = Cesium.Math.PI_OVER_TWO - Math.acos(Cesium.Cartesian3.dot(toFireworks, Cesium.Cartesian3.UNIT_Z));
+var toFireworks = Cartesian3.subtract(emitterInitialLocation, cameraOffset, new Cartesian3());
+Cartesian3.normalize(toFireworks, toFireworks);
+var angle = CesiumMath.PI_OVER_TWO - Math.acos(Cartesian3.dot(toFireworks, Cartesian3.UNIT_Z));
 camera.lookUp(angle);

--- a/src/index.js
+++ b/src/index.js
@@ -1,150 +1,18 @@
 
-import {
-    Cartesian3,
-    Color,
-    defined,
-    Math as CesiumMath,
-    Matrix4,
-    ParticleBurst,
-    ParticleSystem,
-    SphereEmitter,
-    Transforms,
-    Viewer
-} from 'cesium';
-
+import { Cesium3DTileset, createWorldTerrain, IonResource, Viewer } from 'cesium';
 import "cesium/Build/Cesium/Widgets/widgets.css";
 import "./css/main.css";
 
-// Example app
+// This is simplified version of Cesium's Getting Started tutorial.
+// See https://cesium.com/docs/tutorials/getting-started/ for more details.
 
-var viewer = new Viewer('cesiumContainer');
+var viewer = new Viewer('cesiumContainer', {
+    terrainProvider: createWorldTerrain()
+});
 
-var scene = viewer.scene;
-scene.debugShowFramesPerSecond = true;
+var tileset = new Cesium3DTileset({
+    url: IonResource.fromAssetId(40866)
+});
 
-CesiumMath.setRandomNumberSeed(315);
-
-var modelMatrix = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromDegrees(-75.59777, 40.03883));
-var emitterInitialLocation = new Cartesian3(0.0, 0.0, 100.0);
-
-var particleCanvas;
-
-function getImage() {
-    if (!defined(particleCanvas)) {
-        particleCanvas = document.createElement('canvas');
-        particleCanvas.width = 20;
-        particleCanvas.height = 20;
-        var context2D = particleCanvas.getContext('2d');
-        context2D.beginPath();
-        context2D.arc(8, 8, 8, 0, CesiumMath.TWO_PI, true);
-        context2D.closePath();
-        context2D.fillStyle = 'rgb(255, 255, 255)';
-        context2D.fill();
-    }
-    return particleCanvas;
-}
-
-var minimumExplosionSize = 30.0;
-var maximumExplosionSize = 100.0;
-var particlePixelSize = 7.0;
-var burstSize = 400.0;
-var lifetime = 10.0;
-var numberOfFireworks = 20.0;
-
-var emitterModelMatrixScratch = new Matrix4();
-
-function createFirework(offset, color, bursts) {
-    var position = Cartesian3.add(emitterInitialLocation, offset, new Cartesian3());
-    var emitterModelMatrix = Matrix4.fromTranslation(position, emitterModelMatrixScratch);
-    var particleToWorld = Matrix4.multiply(modelMatrix, emitterModelMatrix, new Matrix4());
-    var worldToParticle = Matrix4.inverseTransformation(particleToWorld, particleToWorld);
-
-    var size = CesiumMath.randomBetween(minimumExplosionSize, maximumExplosionSize);
-    var particlePositionScratch = new Cartesian3();
-    var force = function (particle) {
-        var position = Matrix4.multiplyByPoint(worldToParticle, particle.position, particlePositionScratch);
-        if (Cartesian3.magnitudeSquared(position) >= size * size) {
-            Cartesian3.clone(Cartesian3.ZERO, particle.velocity);
-        }
-    };
-
-    var normalSize = (size - minimumExplosionSize) / (maximumExplosionSize - minimumExplosionSize);
-    var minLife = 0.3;
-    var maxLife = 1.0;
-    var life = normalSize * (maxLife - minLife) + minLife;
-
-    scene.primitives.add(new ParticleSystem({
-        image: getImage(),
-        startColor: color,
-        endColor: color.withAlpha(0.0),
-        life: life,
-        speed: 100.0,
-        width: particlePixelSize,
-        height: particlePixelSize,
-        rate: 0,
-        emitter: new SphereEmitter(0.1),
-        bursts: bursts,
-        lifeTime: lifetime,
-        forces: [force],
-        modelMatrix: modelMatrix,
-        emitterModelMatrix: emitterModelMatrix
-    }));
-}
-
-var xMin = -100.0;
-var xMax = 100.0;
-var yMin = -80.0;
-var yMax = 100.0;
-var zMin = -50.0;
-var zMax = 50.0;
-
-var colorOptions = [{
-    minimumRed: 0.75,
-    green: 0.0,
-    minimumBlue: 0.8,
-    alpha: 1.0
-}, {
-    red: 0.0,
-    minimumGreen: 0.75,
-    minimumBlue: 0.8,
-    alpha: 1.0
-}, {
-    red: 0.0,
-    green: 0.0,
-    minimumBlue: 0.8,
-    alpha: 1.0
-}, {
-    minimumRed: 0.75,
-    minimumGreen: 0.75,
-    blue: 0.0,
-    alpha: 1.0
-}];
-
-for (var i = 0; i < numberOfFireworks; ++i) {
-    var x = CesiumMath.randomBetween(xMin, xMax);
-    var y = CesiumMath.randomBetween(yMin, yMax);
-    var z = CesiumMath.randomBetween(zMin, zMax);
-    var offset = new Cartesian3(x, y, z);
-    var color = Color.fromRandom(colorOptions[i % colorOptions.length]);
-
-    var bursts = [];
-    for (var j = 0; j < 3; ++j) {
-        bursts.push(new ParticleBurst({
-            time: CesiumMath.nextRandomNumber() * lifetime,
-            minimum: burstSize,
-            maximum: burstSize
-        }));
-    }
-
-    createFirework(offset, color, bursts);
-}
-
-var camera = viewer.scene.camera;
-var cameraOffset = new Cartesian3(-300.0, 0.0, 0.0);
-camera.lookAtTransform(modelMatrix, cameraOffset);
-camera.lookAtTransform(Matrix4.IDENTITY);
-
-var toFireworks = Cartesian3.subtract(emitterInitialLocation, cameraOffset, new Cartesian3());
-Cartesian3.normalize(toFireworks, toFireworks);
-var angle = CesiumMath.PI_OVER_TWO - Math.acos(Cartesian3.dot(toFireworks, Cartesian3.UNIT_Z));
-camera.lookUp(angle);
+viewer.scene.primitives.add(tileset);
+viewer.zoomTo(tileset);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,19 +20,16 @@ module.exports = [{
         // Needed by Cesium for multiline strings
         sourcePrefix: ''
     },
-    amd: {
-        // Enable webpack-friendly use of require in cesium
-        toUrlUndefined: true
-    },
     node: {
         // Resolve node module use of fs
-        fs: "empty"
+        fs: "empty",
+        Buffer: false,
+        http: "empty",
+        https: "empty",
+        zlib: "empty"
     },
     resolve: {
-        alias: {
-            // Cesium module name
-            cesium: path.resolve(__dirname, cesiumSource)
-        }
+        mainFields: ['module', 'main']
     },
     module: {
         rules: [{
@@ -54,13 +51,6 @@ module.exports = [{
         new webpack.DefinePlugin({
             // Define relative base path in cesium for loading assets
             CESIUM_BASE_URL: JSON.stringify('')
-        }),
-        // Split cesium into a seperate bundle
-        new webpack.optimize.CommonsChunkPlugin({
-            name: 'cesium',
-            minChunks: function (module) {
-                return module.context && module.context.indexOf('cesium') !== -1;
-            }
         })
     ],
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,22 +4,17 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-// The path to the cesium source code
-const cesiumSource = 'node_modules/cesium/Source';
-const cesiumWorkers = '../Build/Cesium/Workers';
-
 module.exports = [{
+    mode: 'development',
     context: __dirname,
     entry: {
         app: './src/index.js'
     },
     output: {
         filename: '[name].js',
-        path: path.resolve(__dirname, 'dist'),
-
-        // Needed by Cesium for multiline strings
-        sourcePrefix: ''
+        path: path.resolve(__dirname, 'dist')
     },
+    devtool: 'eval',
     node: {
         // Resolve node module use of fs
         fs: "empty",
@@ -45,9 +40,10 @@ module.exports = [{
             template: 'src/index.html'
         }),
         // Copy Cesium Assets, Widgets, and Workers to a static directory
-        new CopyWebpackPlugin([{from: path.join(cesiumSource, cesiumWorkers), to: 'Workers'}]),
-        new CopyWebpackPlugin([{from: path.join(cesiumSource, 'Assets'), to: 'Assets'}]),
-        new CopyWebpackPlugin([{from: path.join(cesiumSource, 'Widgets'), to: 'Widgets'}]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/Workers', to: 'Workers' }]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/ThirdParty', to: 'ThirdParty' }]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/Assets', to: 'Assets' }]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/Widgets', to: 'Widgets' }]),
         new webpack.DefinePlugin({
             // Define relative base path in cesium for loading assets
             CESIUM_BASE_URL: JSON.stringify('')

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -21,29 +21,22 @@ module.exports = [{
         // Needed by Cesium for multiline strings
         sourcePrefix: ''
     },
-    amd: {
-        // Enable webpack-friendly use of require in cesium
-        toUrlUndefined: true
-    },
     node: {
         // Resolve node module use of fs
-        fs: "empty"
+        fs: "empty",
+        Buffer: false,
+        http: "empty",
+        https: "empty",
+        zlib: "empty"
     },
     resolve: {
-        alias: {
-            // Cesium module name
-            cesium: path.resolve(__dirname, cesiumSource)
-        }
+        mainFields: ['module', 'main']
     },
     module: {
         rules: [{
             test: /\.css$/,
             use: ['style-loader', {
-                loader: 'css-loader',
-                options: {
-                    // Minify css
-                    minimize: true
-                }
+                loader: 'css-loader'
             }]
         }, {
             test: /\.(png|gif|jpg|jpeg|svg|xml|json)$/,
@@ -76,13 +69,6 @@ module.exports = [{
             CESIUM_BASE_URL: JSON.stringify('')
         }),
         // Uglify js files
-        new UglifyJsPlugin(),
-        // Split cesium into a seperate bundle
-        new webpack.optimize.CommonsChunkPlugin({
-            name: 'cesium',
-            minChunks: function (module) {
-                return module.context && module.context.indexOf('cesium') !== -1;
-            }
-        })
+        new UglifyJsPlugin()
     ]
 }];

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -3,23 +3,16 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-
-// The path to the cesium source code
-const cesiumSource = 'node_modules/cesium/Source';
-const cesiumWorkers = '../Build/Cesium/Workers';
 
 module.exports = [{
+    mode: 'production',
     context: __dirname,
     entry: {
         app: './src/index.js'
     },
     output: {
         filename: '[name].js',
-        path: path.resolve(__dirname, 'dist'),
-
-        // Needed by Cesium for multiline strings
-        sourcePrefix: ''
+        path: path.resolve(__dirname, 'dist')
     },
     node: {
         // Resolve node module use of fs
@@ -35,9 +28,8 @@ module.exports = [{
     module: {
         rules: [{
             test: /\.css$/,
-            use: ['style-loader', {
-                loader: 'css-loader'
-            }]
+            use: ['style-loader', { loader: 'css-loader' }],
+            sideEffects: true
         }, {
             test: /\.(png|gif|jpg|jpeg|svg|xml|json)$/,
             use: ['url-loader']
@@ -45,7 +37,8 @@ module.exports = [{
             // Remove pragmas
             test: /\.js$/,
             enforce: 'pre',
-            include: path.resolve(__dirname, cesiumSource),
+            include: path.resolve(__dirname, 'node_modules/cesium/Source'),
+            sideEffects: false,
             use: [{
                 loader: 'strip-pragma-loader',
                 options: {
@@ -56,19 +49,21 @@ module.exports = [{
             }]
         }]
     },
+    optimization: {
+        usedExports: true
+    },
     plugins: [
         new HtmlWebpackPlugin({
             template: 'src/index.html'
         }),
         // Copy Cesium Assets, Widgets, and Workers to a static directory
-        new CopyWebpackPlugin([{from: path.join(cesiumSource, cesiumWorkers), to: 'Workers'}]),
-        new CopyWebpackPlugin([{from: path.join(cesiumSource, 'Assets'), to: 'Assets'}]),
-        new CopyWebpackPlugin([{from: path.join(cesiumSource, 'Widgets'), to: 'Widgets'}]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/Workers', to: 'Workers' }]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/ThirdParty', to: 'ThirdParty' }]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/Assets', to: 'Assets' }]),
+        new CopyWebpackPlugin([{ from: 'node_modules/cesium/Build/Cesium/Widgets', to: 'Widgets' }]),
         new webpack.DefinePlugin({
             // Define relative base path in cesium for loading assets
             CESIUM_BASE_URL: JSON.stringify('')
-        }),
-        // Uglify js files
-        new UglifyJsPlugin()
+        })
     ]
 }];


### PR DESCRIPTION
I know almost nothing about webpack, but this updates it to use a pre-release package of Cesium with ES6 support (which will become 1.63 so we can wait until that is out before we merge this).

It also switches the demo to use the latest version of all libraries and resolve packages from node the way most JS libraries work these days.

I noticed the fireworks no longer work in master or in this branch, I think a more practical example that loads a tileset from ion or something may be a better and simpler dmoe; but that can be in another PR.

I'm sure there are other things that can be simplified here as well, but my main concern was just updating everything.  Open to suggestions (or someone else can just pick up this PR and do more if they want).

My main goal here was to make sure that Cesium 1.63 still worked with webpack and it does (and in a better/more modern way than it did previously).