### PR TITLE
ContextReplacementPlugin is used to suppress critical dependency warnings caused by require.toUrl in buildModuleUrl

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,11 +53,7 @@ module.exports = [{
             // in cesium/Source/Core/buildModuleUrl.js
             const { resource, context, dependencies } = ctx;
             if (resource === context) {
-                dependencies.forEach(dependency => {
-                    if (dependency.userRequest === '.' && dependency.critical) {
-                        dependency.critical = false;
-                    }
-                });
+                dependencies.forEach(dependency => dependency.critical = false);
             }
             return ctx;
         })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,19 @@ module.exports = [{
         new webpack.DefinePlugin({
             // Define relative base path in cesium for loading assets
             CESIUM_BASE_URL: JSON.stringify('')
+        }),
+        new webpack.ContextReplacementPlugin(/cesium\/Source\/Core/, ctx => {
+            // Suppress warnings "require function is used in a way in which dependencies cannot be statically extracted"
+            // in cesium/Source/Core/buildModuleUrl.js
+            const { resource, context, dependencies } = ctx;
+            if (resource === context) {
+                dependencies.forEach(dependency => {
+                    if (dependency.userRequest === '.' && dependency.critical) {
+                        dependency.critical = false;
+                    }
+                });
+            }
+            return ctx;
         })
     ],
 

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -64,6 +64,15 @@ module.exports = [{
         new webpack.DefinePlugin({
             // Define relative base path in cesium for loading assets
             CESIUM_BASE_URL: JSON.stringify('')
+        }),
+        new webpack.ContextReplacementPlugin(/cesium\/Source\/Core/, ctx => {
+            // Suppress warnings "require function is used in a way in which dependencies cannot be statically extracted"
+            // in cesium/Source/Core/buildModuleUrl.js
+            const { resource, context, dependencies } = ctx;
+            if (resource === context) {
+                dependencies.forEach(dependency => dependency.critical = false);
+            }
+            return ctx;
         })
     ]
 }];


### PR DESCRIPTION
Fixes #6.

[ContextReplacementPlugin](https://webpack.js.org/plugins/context-replacement-plugin/)