### PR TITLE
Webpack Fix (start and build scripts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "node_modules/.bin/webpack --config webpack.config.js",
-    "start": "node_modules/.bin/webpack serve --config webpack.config.js --open"
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack serve --config webpack.config.js --open"
   },
   "devDependencies": {
     "cesium": "^1.84.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "start": "webpack serve --config webpack.config.js --open"
+    "start":"webpack serve --config webpack.config.js --open"
   },
   "devDependencies": {
     "cesium": "^1.84.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "start":"webpack serve --config webpack.config.js --open"
+    "start": "webpack serve --config webpack.config.js --open"
   },
   "devDependencies": {
     "cesium": "^1.84.0",


### PR DESCRIPTION
Earlier this morning I was running our cesium-webpack-example repository on my Windows build. I noticed that I was able to run `npm install` successfully, however, I received an error when running `npm start`.

This pull request addresses this error by updating the `start` and `build` scripts.