### PR TITLE
treeshake example

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.2",
+    "strip-pragma-loader": "^1.0.1",
     "style-loader": "^3.2.1",
     "url-loader": "^4.1.1",
     "webpack": "^5.51.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
+import { Cartesian3 } from 'cesium';
+
+const cartesian = new Cartesian3(1,1,1);
+console.log(Cartesian3.magnitude(cartesian))
+
+/*
 import { Ion, Viewer, createWorldTerrain, createOsmBuildings, Cartesian3, Math } from "cesium";
 import "cesium/Widgets/widgets.css";
 import "../src/css/main.css"
@@ -22,3 +28,4 @@ viewer.camera.flyTo({
     pitch : Math.toRadians(-15.0),
   }
 });
+*/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,21 @@ module.exports = {
         }, {
             test: /\.(png|gif|jpg|jpeg|svg|xml|json)$/,
             use: [ 'url-loader' ]
+        }, {
+            test: /\.js$/,
+            enforce: 'pre',
+            include: path.resolve(__dirname, 'node_modules/cesium/Source'),
+            sideEffects: false,
+            use: [
+                {
+                    loader: 'strip-pragma-loader',
+                    options: {
+                        pragmas: {
+                            debug: false
+                        }
+                    }
+                }
+            ]
         }]
     },
     plugins: [


### PR DESCRIPTION
It would be good to include an example of best practice for more production oriented builds, like removing debug pragmas and tree shaking etc.

e.g. in this toy example the build size is reduced 16.4 MiB => 78.5 KiB with Cesium 1.96.

Note that `sideEffects: false` can alternatively live in the Cesium `package.json`.  It can include a list of files if some do have side effects that need to be respected https://webpack.js.org/guides/tree-shaking/
