### PR TITLE
Updates from latest CesiumJS release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist/
 /node_modules/
 package-lock.json
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '10'
-  - '12'
+  - '14'
+  - '16'
 script:
   - npm run build

--- a/README.md
+++ b/README.md
@@ -4,54 +4,50 @@ A minimal recommended setup for an applications using [Cesium](https://cesium.co
 
 [![Build Status](https://travis-ci.org/CesiumGS/cesium-webpack-example.svg?branch=using-custom-loader)](https://travis-ci.org/CesiumGS/cesium-webpack-example)
 
-### Running this application
+## Running this application
 
-	npm install
-	npm start
+````sh
+npm install
+npm start
+````
 
 Navigate to `localhost:8080`.
 
-##### Available scripts
+### Available scripts
 
 * `npm start` - Runs a webpack build with `webpack.config.js` and starts a development server
 * `npm run build` - Runs a webpack build with `webpack.config.js`
-* `npm run release` - Runs an optimized webpack build with `webpack.release.config.js`
-* `npm run serve-release` - Runs an optimized webpack build with `webpack.release.config.js` and starts a development server
 
-##### Configurations
+## Requiring Cesium in your application
 
-We've included two webpack configuration files in this repository. `webpack.config.js` contains configuration for development while `webpack.release.config.js` contains an optimized configuration for production use.
+We recommend [importing named exports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) from the Cesium ES module, via the `import` keyword. This allows webpack to [tree shake](https://webpack.js.org/guides/tree-shaking/) your application automatically.
 
-### Requiring Cesium in your application
+### Import named modules from Cesium
 
-We recommend using Cesium as an [ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) module, via the `import` keyword.
+````js
+import { Color } from 'cesium';
+var c = Color.fromRandom();
+````
 
-#### Import named modules from Cesium
+### Import Cesium static asset files
 
-	import { Color } from 'cesium';
-	var c = Color.fromRandom();
+````js
+import "cesium/Build/Cesium/Widgets/widgets.css";
+````
 
-#### Import Cesium static asset files
-	
-	import "cesium/Build/Cesium/Widgets/widgets.css";
-
-### Treeshaking
-
-`webpack.release.config.js` enables tree-shaking of CesiumJS modules so that unused modules are not included in the production bundle. See Webpack's [Tree Shaking](https://webpack.js.org/guides/tree-shaking/) documentation for more details.
-
-##### Removing pragmas
+## Removing pragmas
 
 To remove pragmas such as a traditional Cesium release build, use the [`strip-pragma-loader`](https://www.npmjs.com/package/strip-pragma-loader).
 
 Install the plugin with npm,
 
-```
+````sh
 npm install strip-pragma-loader --save-dev
-```
+````
 
 and include the loader in `module.rules` with `debug` set to `false`.
 
-```
+````js
 rules: [{
 	test: /\.js$/,
 	enforce: 'pre',
@@ -65,7 +61,7 @@ rules: [{
 		}
 	}]
 }]
-```
+````
 
 ## Contributions
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "webpack serve --config webpack.config.js --open"
   },
   "devDependencies": {
-    "cesium": "^1.84.0",
+    "cesium": "^1.97.0",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { Ion, Viewer, createWorldTerrain, createOsmBuildings, Cartesian3, Math } from "cesium";
-import "cesium/Widgets/widgets.css";
+import "cesium/Build/Cesium/Widgets/widgets.css";
 import "../src/css/main.css"
 
 // Your access token can be found at: https://cesium.com/ion/tokens.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,14 +16,8 @@ module.exports = {
         path: path.resolve(__dirname, 'dist'),
         sourcePrefix: ''
     },
-    amd: {
-        // Enable webpack-friendly use of require in Cesium
-        toUrlUndefined: true
-    },
     resolve: {
-        alias: {
-            cesium: path.resolve(__dirname, cesiumSource)
-        },
+        fallback: { "https": false, "zlib": false, "http": false, "url": false },
         mainFiles: ['index', 'Cesium']
     },
     module: {


### PR DESCRIPTION
This updates our example code to reflect the best practices as of the latest Cesium release, 1.97. Notably, this includes [support for tree shaking](https://github.com/CesiumGS/cesium/pull/10714) and [support for importing CSS files without additional configuration](https://github.com/CesiumGS/cesium/pull/10711).

I also updated the CI node versions to match the minimum recommendations from CesiumJS.