### PR TITLE
[Bugfix] Fix 3DTile Rendering

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,8 @@ module.exports = {
             patterns: [
                 { from: path.join(cesiumSource, cesiumWorkers), to: 'Workers' },
                 { from: path.join(cesiumSource, 'Assets'), to: 'Assets' },
-                { from: path.join(cesiumSource, 'Widgets'), to: 'Widgets' }
+                { from: path.join(cesiumSource, 'Widgets'), to: 'Widgets' },
+                { from: path.join(cesiumSource, 'ThirdParty'), to: 'ThirdParty' }
             ]
         }),
         new webpack.DefinePlugin({


### PR DESCRIPTION
PR Deliverables
- [Bugfix] Fix 3DTile Rendering

Developer Notes
- 3DTile rendering was broken due to the inability to load `ThirdParty/draco_decoder.wasm`
- Added `ThirdParty` to webpack CopyPlugin config