### PR TITLE
Fix example and update cesium version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,9 @@
   "root": true,
   "extends": ["cesium/browser"],
   "plugins": ["html", "es"],
+  "parserOptions": {
+    "ecmaVersion": 2023
+  },
   "rules": {
     "no-unused-vars": ["error", { "vars": "all", "args": "none" }]
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier-check": "prettier --check --no-config \"**/*\""
   },
   "devDependencies": {
-    "cesium": "^1.97.0",
+    "cesium": "^1.113.0",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.2.0",
     "eslint": "^8.56.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import {
   Ion,
   Viewer,
-  createWorldTerrain,
-  createOsmBuildings,
   Cartesian3,
   Math,
+  Terrain,
+  createOsmBuildingsAsync,
 } from "cesium";
 import "cesium/Build/Cesium/Widgets/widgets.css";
 import "../src/css/main.css";
@@ -16,11 +16,12 @@ Ion.defaultAccessToken =
 
 // Initialize the Cesium Viewer in the HTML element with the `cesiumContainer` ID.
 const viewer = new Viewer("cesiumContainer", {
-  terrainProvider: createWorldTerrain(),
+  terrain: Terrain.fromWorldTerrain(),
 });
 
 // Add Cesium OSM Buildings, a global 3D buildings layer.
-viewer.scene.primitives.add(createOsmBuildings());
+const osmBuildingsTileset = await createOsmBuildingsAsync();
+viewer.scene.primitives.add(osmBuildingsTileset);
 
 // Fly the camera to San Francisco at the given longitude, latitude, and height.
 viewer.camera.flyTo({

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import {
-  Ion,
   Viewer,
   Cartesian3,
   Math,
@@ -9,10 +8,9 @@ import {
 import "cesium/Build/Cesium/Widgets/widgets.css";
 import "../src/css/main.css";
 
-// Your access token can be found at: https://cesium.com/ion/tokens.
-// This is the default access token
-Ion.defaultAccessToken =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlYWE1OWUxNy1mMWZiLTQzYjYtYTQ0OS1kMWFjYmFkNjc5YzciLCJpZCI6NTc3MzMsImlhdCI6MTYyNzg0NTE4Mn0.XcKpgANiY19MC4bdFUXMVEBToBmqS8kuYpUlxJHYZxk";
+// CesiumJS has a default access token built in but it's not meant for active use.
+// please set your own access token can be found at: https://cesium.com/ion/tokens.
+// Ion.defaultAccessToken = "YOUR TOKEN HERE";
 
 // Initialize the Cesium Viewer in the HTML element with the `cesiumContainer` ID.
 const viewer = new Viewer("cesiumContainer", {


### PR DESCRIPTION
Fix the example code calling a deprecated function and actually load the correct terrain.

I also set eslint to es2023 to allow for top level `await` 

This branches off of #50 

Fixes #49
Fixes #44
