### PR TITLE
Remove node externals for build

### DIFF
--- a/webpack-4/package.json
+++ b/webpack-4/package.json
@@ -25,7 +25,7 @@
     "start:built": "npx http-server -a localhost -p 8080 dist/"
   },
   "dependencies": {
-    "cesium": "^1.113.0"
+    "cesium": "^1.114.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/webpack-5/README.md
+++ b/webpack-5/README.md
@@ -64,6 +64,19 @@ new CopyWebpackPlugin({
 }),
 ```
 
+## CesiumJS before version `1.114`
+
+If you are using a version of CesiumJS before `1.114` you will need to modify the config to tell it to ignore some external node dependencies. Modify the `resolve` section to include the below:
+
+```js
+  resolve: {
+    fallback: { https: false, zlib: false, http: false, url: false },
+    mainFiles: ["index", "Cesium"],
+  },
+```
+
+See cesium PR [#11773](https://github.com/CesiumGS/cesium/pull/11773) for more information
+
 ## Removing pragmas
 
 To remove pragmas such as a traditional Cesium release build, use the [`strip-pragma-loader`](https://www.npmjs.com/package/strip-pragma-loader).

--- a/webpack-5/package.json
+++ b/webpack-5/package.json
@@ -25,7 +25,7 @@
     "start:built": "npx http-server -a localhost -p 8080 dist/"
   },
   "dependencies": {
-    "cesium": "^1.113.0"
+    "cesium": "^1.114.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^9.1.0",

--- a/webpack-5/webpack.config.js
+++ b/webpack-5/webpack.config.js
@@ -21,7 +21,6 @@ module.exports = {
     sourcePrefix: "",
   },
   resolve: {
-    fallback: { https: false, zlib: false, http: false, url: false },
     mainFiles: ["index", "Cesium"],
   },
   module: {


### PR DESCRIPTION
With the release of [CesiumJS `v1.114`](https://github.com/CesiumGS/cesium/releases/tag/1.114) which included https://github.com/CesiumGS/cesium/pull/11773 the external node modules are no longer necessary and can be excluded from the config. This pr removes them.

## Testing

This only affects the Webpack 5 version but ensure that Webpack 4 still works

- clean your local project
- In each webpack directory, `webpack-4` and `webpack-5`
    - run `npm install`
    - run `npm run start` and check the local version works
    - run `npm run build` and make sure there are no errors
    - run `npm run start:built` and make sure the local built version still works