### PR TITLE
Add missing css documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ new CopyWebpackPlugin({
 }),
 ```
 
+Additionally you will have to import a different widgets css file in `src/index.js`.
+
+```js
+// Change this import
+import "cesium/Build/Cesium/Widgets/widgets.css";
+
+// To this one from the cesium/engine package
+import "@cesium/engine/Source/Widget/CesiumWidget.css";
+```
+
 ## Removing pragmas
 
 To remove pragmas such as a traditional Cesium release build, use the [`strip-pragma-loader`](https://www.npmjs.com/package/strip-pragma-loader).

--- a/webpack-4/README.md
+++ b/webpack-4/README.md
@@ -64,6 +64,16 @@ new CopyWebpackPlugin({
 }),
 ```
 
+Additionally you will have to import a different widgets css file in `src/index.js`.
+
+```js
+// Change this import
+import "cesium/Build/Cesium/Widgets/widgets.css";
+
+// To this one from the cesium/engine package
+import "@cesium/engine/Source/Widget/CesiumWidget.css";
+```
+
 ## Removing pragmas
 
 To remove pragmas such as a traditional Cesium release build, use the [`strip-pragma-loader`](https://www.npmjs.com/package/strip-pragma-loader).

--- a/webpack-5/README.md
+++ b/webpack-5/README.md
@@ -64,6 +64,16 @@ new CopyWebpackPlugin({
 }),
 ```
 
+Additionally you will have to import a different widgets css file in `src/index.js`.
+
+```js
+// Change this import
+import "cesium/Build/Cesium/Widgets/widgets.css";
+
+// To this one from the cesium/engine package
+import "@cesium/engine/Source/Widget/CesiumWidget.css";
+```
+
 ## CesiumJS before version `1.114`
 
 If you are using a version of CesiumJS before `1.114` you will need to modify the config to tell it to ignore some external node dependencies. Modify the `resolve` section to include the below:


### PR DESCRIPTION
I realized I never copied over the updated documentation about changing the CSS path when using `@cesium/engine` instead of `cesium`